### PR TITLE
fix: provider version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this module will be documented in this file.
 
+## [v2.0.1] - 2023-06-15
+
+### Changed
+
+- When running with a provider version of 6 or higher, certain modules may not function properly. However, we can address the modules that are not compatible with version 6 to ensure compatibility. This way, we don't need to edit all the modules. So we update the constraint to `>= 5.0.0` at the module level.
+
 ## [v2.0.0] - 2023-06-08
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Terraform module with create vpc and subnet resources on AWS.
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                                      | Version           |
-|---------------------------------------------------------------------------|-------------------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0          |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0, < 6.0.0 |
+| Name                                                                      | Version  |
+|---------------------------------------------------------------------------|----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0 |
 
 ## Providers
 
 | Name                                              | Version |
 |---------------------------------------------------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.1.0   |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.3.0   |
 
 ## Modules
 

--- a/modules/flow-log/README.md
+++ b/modules/flow-log/README.md
@@ -38,23 +38,23 @@ module "flow_log" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name                                                                      | Version           |
-|---------------------------------------------------------------------------|-------------------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0          |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0, < 6.0.0 |
+| Name                                                                      | Version  |
+|---------------------------------------------------------------------------|----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0 |
 
 ## Providers
 
 | Name                                              | Version |
 |---------------------------------------------------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.31.0  |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.3.0   |
 
 ## Modules
 
 | Name                                                                                                                     | Source            | Version |
 |--------------------------------------------------------------------------------------------------------------------------|-------------------|---------|
-| <a name="module_centralize_flow_log_bucket"></a> [centralize\_flow\_log\_bucket](#module\_centralize\_flow\_log\_bucket) | oozou/s3/aws      | 2.0.0   |
-| <a name="module_flow_log_kms"></a> [flow\_log\_kms](#module\_flow\_log\_kms)                                             | oozou/kms-key/aws | 2.0.0   |
+| <a name="module_centralize_flow_log_bucket"></a> [centralize\_flow\_log\_bucket](#module\_centralize\_flow\_log\_bucket) | oozou/s3/aws      | 2.0.1   |
+| <a name="module_flow_log_kms"></a> [flow\_log\_kms](#module\_flow\_log\_kms)                                             | oozou/kms-key/aws | 2.0.1   |
 
 ## Resources
 

--- a/modules/flow-log/kms.tf
+++ b/modules/flow-log/kms.tf
@@ -3,7 +3,7 @@
 /* -------------------------------------------------------------------------- */
 module "flow_log_kms" {
   source  = "oozou/kms-key/aws"
-  version = "2.0.0"
+  version = "2.0.1"
 
   count = 1 - local.account_mode
 

--- a/modules/flow-log/s3.tf
+++ b/modules/flow-log/s3.tf
@@ -1,6 +1,6 @@
 module "centralize_flow_log_bucket" {
   source  = "oozou/s3/aws"
-  version = "2.0.0"
+  version = "2.0.1"
 
   count = 1 - local.account_mode
 

--- a/modules/flow-log/versions.tf
+++ b/modules/flow-log/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0, < 6.0.0"
+      version = ">= 5.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0, < 6.0.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:

### Changed

- When running with a provider version of 6 or higher, certain modules may not function properly. However, we can address the modules that are not compatible with version 6 to ensure compatibility. This way, we don't need to edit all the modules. So we update the constraint to `>= 5.0.0` at the module level.

## Why :pleading_face:

- Simplify future upgrade