### PR TITLE
chore: support resource tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this module will be documented in this file.
 
+## [v1.1.8] - 2023-07-27
+
+### Added
+
+- Support resources tagging with these variables: `var.vpc_tags`, `var.dhcp_options_tags`, `var.public_subnet_tags`, `var.private_subnet_tags`, `var.database_subnet_tags`, `var.secondary_subnet_tags`, `var.public_route_table_tags`, `var.private_route_table_tags`, `var.database_route_table_tags`, `var.secondary_route_table_tags`
+
 ## [v1.1.7] - 2022-07-27
 
 ### Changed

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,13 @@ variable "is_enable_ipv6" {
   type        = bool
   default     = false
 }
+
+variable "vpc_tags" {
+  description = "Additional tags for the VPC"
+  type        = map(string)
+  default     = {}
+}
+
 /* ------------------------------ DHCP options ------------------------------ */
 variable "is_enable_dhcp_options" {
   description = "Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type"
@@ -107,6 +114,12 @@ variable "dhcp_options_netbios_node_type" {
   description = "Specify netbios node_type for DHCP options set (requires enable_dhcp_options set to true)"
   type        = string
   default     = ""
+}
+
+variable "dhcp_options_tags" {
+  description = "Additional tags for the DHCP option"
+  type        = map(string)
+  default     = {}
 }
 
 /* -------------------------------------------------------------------------- */
@@ -151,25 +164,85 @@ variable "public_subnets" {
   description = "The CIDR block for the public subnets. Required 3 subnets for availability zones"
   type        = list(string)
 }
+
+variable "public_subnet_tags" {
+  description = "Additional tags for the public subnets"
+  type        = map(string)
+  default     = {}
+}
 /* ----------------------------- private subnets ---------------------------- */
 variable "private_subnets" {
   description = "The CIDR block for the private subnets. Required 3 subnets for availability zones"
   type        = list(string)
 }
+
+variable "private_subnet_tags" {
+  description = "Additional tags for the private subnets"
+  type        = map(string)
+  default     = {}
+}
+
 /* ---------------------------- database subnets ---------------------------- */
 variable "database_subnets" {
-  description = "The CIDR block for the database subnets. Required 3 subnets for availability zones"
+  description = "The CIDR block for the database subnets."
   type        = list(string)
   default     = []
 }
 
+variable "database_subnet_tags" {
+  description = "Additional tags for the database subnets"
+  type        = map(string)
+  default     = {}
+}
+
+/* ---------------------------- secondary subnets --------------------------- */
+variable "secondary_subnets" {
+  description = "The CIDR block for the secondary subnets."
+  type        = list(string)
+  default     = []
+}
+
+variable "secondary_subnet_tags" {
+  description = "Additional tags for the secondary subnets"
+  type        = map(string)
+  default     = {}
+}
+
 /* -------------------------------------------------------------------------- */
-/*                            Database Route Table                            */
+/*                                 Route Table                                */
 /* -------------------------------------------------------------------------- */
+/* --------------------------------- Public --------------------------------- */
+variable "public_route_table_tags" {
+  description = "Additional tags for the public route tables"
+  type        = map(string)
+  default     = {}
+}
+
+/* --------------------------------- Private -------------------------------- */
+variable "private_route_table_tags" {
+  description = "Additional tags for the private route tables"
+  type        = map(string)
+  default     = {}
+}
+
+/* -------------------------------- Database -------------------------------- */
 variable "is_create_database_subnet_route_table" {
   description = "Whether to create database subnet or not"
   type        = bool
   default     = true
+}
+
+variable "database_route_table_tags" {
+  description = "Additional tags for the database route tables"
+  type        = map(string)
+  default     = {}
+}
+
+/* -------------------------------- Secondary ------------------------------- */
+variable "secondary_route_table_tags" {
+  description = "Additional tags for the secondary route tables"
+  type        = map(string)
+  default     = {}
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:

### Added

- Support resources tagging with these variables: `var.vpc_tags`, `var.dhcp_options_tags`, `var.public_subnet_tags`, `var.private_subnet_tags`, `var.database_subnet_tags`, `var.secondary_subnet_tags`, `var.public_route_table_tags`, `var.private_route_table_tags`, `var.database_route_table_tags`, `var.secondary_route_table_tags`

## Why :pleading_face:

- Some resource require specfic additional tagging ex. karpenter

